### PR TITLE
Setting default data

### DIFF
--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -3,7 +3,7 @@ require 'json_logic/truthy'
 require 'json_logic/operation'
 
 module JSONLogic
-  def self.apply(logic, data)
+  def self.apply(logic, data = {})
     return logic unless logic.is_a?(Hash)                # pass-thru
     operator, values = logic.first                       # unwrap single-key hash
     values = [values] unless values.is_a?(Array)         # syntactic sugar


### PR DESCRIPTION
You can set data to default  `{}`

```
JSONLogic.apply({ "==" => [1, 1] }, {})
```

and you can write syntax cleaner

```
JSONLogic.apply({ "==" => [1, 1] })
```