### PR TITLE
Allow symbolic operation in logic hashes

### DIFF
--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -118,13 +118,13 @@ module JSONLogic
     end
 
     def self.is_standard?(operator)
-      LAMBDAS.keys.include?(operator)
+      LAMBDAS.key?(operator.to_s)
     end
 
     # Determine if values associated with operator need to be re-interpreted for each iteration(ie some kind of iterator)
     # or if values can just be evaluated before passing in.
     def self.is_iterable?(operator)
-      ['filter', 'some', 'all', 'none', 'in', 'map', 'reduce'].any? { |o| o == operator }
+      ['filter', 'some', 'all', 'none', 'in', 'map', 'reduce'].include?(operator.to_s)
     end
 
     def self.add_operation(operator, function)

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -26,6 +26,12 @@ class JSONLogicTest < Minitest::Test
     assert_equal([{'id' => 2}], JSONLogic.filter(filter, data))
   end
 
+  def test_symbol_operation
+    logic = {'==': [{var: "id"}, 1]}
+    data = JSON.parse(%Q|{"id": 1}|)
+    assert_equal(true, JSONLogic.apply(logic, data))
+  end
+
   def test_add_operation
     new_operation = ->(v, d) { v.map { |x| x + 5 } }
     JSONLogic.add_operation('fives', new_operation)


### PR DESCRIPTION
Hey,

I encounter #7 while integrating json-logic-ruby in my project. I understand that `apply` expects a stringify_keys as this is default output from `JSON.parse` but input can be provided manually or it can can symbolized keys (with proper parameter to JSON.parse). 

Would be great to have this feature in this gem.

Fixes #7.