### PR TITLE
Handle arrays with logic correctly

### DIFF
--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -4,7 +4,12 @@ require 'json_logic/truthy'
 require 'json_logic/operation'
 module JSONLogic
   def self.apply(logic, data)
+    if logic.is_a?(Array)
+      return logic.map { |val| apply(val, data) }
+    end
+
     return logic unless logic.is_a?(Hash)                  # pass-thru
+
     data = data.stringify_keys if data.is_a?(Hash)         # Stringify keys to keep out problems with symbol/string mismatch
     operator, values = logic.first                         # unwrap single-key hash
     values = [values] unless values.is_a?(Array)           # syntactic sugar

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -15,7 +15,12 @@ class JSONLogicTest < Minitest::Test
     define_method("test_#{count}") do
       result = JSONLogic.apply(pattern[0], pattern[1])
       msg = "#{pattern[0].to_json} (data: #{pattern[1].to_json})"
-      assert_equal(pattern[2], result, msg)
+
+      if pattern[2].nil?
+        assert_nil(result, msg)
+      else
+        assert_equal(pattern[2], result, msg)
+      end
     end
     count += 1
   end

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -44,4 +44,19 @@ class JSONLogicTest < Minitest::Test
     data = JSON.parse(%Q|{"num": 1}|)
     assert_equal([6], JSONLogic.apply(rules, data))
   end
+
+  def test_array_with_logic
+    assert_equal [1, 2, 3], JSONLogic.apply([1, {"var" => "x"}, 3], {"x" => 2})
+
+    assert_equal [42], JSONLogic.apply(
+      {
+        "if" => [
+          {"var" => "x"},
+          [{"var" => "y"}],
+          99
+        ]
+      },
+      { "x" => true, "y" => 42}
+    )
+  end
 end


### PR DESCRIPTION
This introduces two changes:

- fixing deprecation warning coming from Minitest
- properly handling of arrays with logic

The first change is rather trivial, but the second requires some explanation with examples.

**Example 1**

```ruby
JSONLogic.apply([1, {"var" => "x"}, 3], {"x" => 2})
```

Expected value is `[1, 2, 3]`, but actual is `[1, {"var"=>"x"}, 3]`.

**Example 2**

```ruby
JSONLogic.apply(
  {
    "if" => [
      {"var" => "x"},
      [{"var" => "z"}],
      99
    ]
  },
  { "x" => true, "y" => true, "z" => 42}
)
```

Expected value is `[42]`, actual is `[{"var"=>"z"}]`.

I am planning to extend the original test suite at http://jsonlogic.com/tests.json with the above examples, but it may take some time to merge. That's why I've added tests in the code. Those can be removed after extending the original test suite.