### PR TITLE
Fix deep_fetch when fetched value is Boolean false

### DIFF
--- a/lib/core_ext/deep_fetch.rb
+++ b/lib/core_ext/deep_fetch.rb
@@ -1,13 +1,15 @@
 class Hash
   def deep_fetch(key, default = nil)
     keys = key.to_s.split('.')
-    dig(*keys) || default rescue default
+    value = dig(*keys) rescue default
+    value.nil? ? default : value  # value can be false (Boolean)
   end
 end
 
 class Array
   def deep_fetch(index, default = nil)
     indexes = index.to_s.split('.').map(&:to_i)
-    dig(*indexes) || default rescue default
+    value = dig(*indexes) rescue default
+    value.nil? ? default : value  # value can be false (Boolean)
   end
 end


### PR DESCRIPTION
Currently, if the deep fetched array or hash value is a Boolean false, the output is nil (false || nil gives nil), when it should actually be false. This PR fixes the issue.