### PR TITLE
add support for ruby 2.2

### DIFF
--- a/json_logic.gemspec
+++ b/json_logic.gemspec
@@ -18,10 +18,12 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_development_dependency 'bundler',  '~> 1.13'
   spec.add_development_dependency 'rake',     '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'pry'
+  spec.add_runtime_dependency 'backport_dig' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 end

--- a/lib/core_ext/deep_fetch.rb
+++ b/lib/core_ext/deep_fetch.rb
@@ -1,3 +1,5 @@
+require 'backport_dig' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+
 class Hash
   def deep_fetch(key, default = nil)
     keys = key.to_s.split('.')

--- a/lib/json_logic/version.rb
+++ b/lib/json_logic/version.rb
@@ -1,3 +1,3 @@
 module JSONLogic
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -37,6 +37,12 @@ class JSONLogicTest < Minitest::Test
     assert_equal(true, JSONLogic.apply(logic, data))
   end
 
+  def test_false_value
+    logic = {'==': [{var: "flag"}, false]}
+    data = JSON.parse(%Q|{"flag": false}|)
+    assert_equal(true, JSONLogic.apply(logic, data))
+  end
+
   def test_add_operation
     new_operation = ->(v, d) { v.map { |x| x + 5 } }
     JSONLogic.add_operation('fives', new_operation)


### PR DESCRIPTION
Add support for ruby 2.2 including gem backport_dig to implement Hash#dig, Array#dig. 