### PR TITLE
Returns empty array if filter logic got the data which is not array o…

### DIFF
--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -16,6 +16,8 @@ module JSONLogic
         end
       end,
       'filter' => -> (v,d) do
+        return [] unless v[0].is_a?(Array)
+
         v[0].select do |val|
           interpolated_block(v[1], val).truthy?
         end

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -87,7 +87,7 @@ class JSONLogicTest < Minitest::Test
       },
       { "x" => "foo"}
     )
-    
+
     assert_equal false, JSONLogic.apply(
       {
         "in" => [
@@ -96,6 +96,18 @@ class JSONLogicTest < Minitest::Test
         ]
       },
       { "x" => "foo", "y" => "bar" }
+    )
+  end
+
+  def test_filter_with_non_array
+    assert_equal [], JSONLogic.apply(
+      {
+        "filter" => [
+          { "var" => "x" },
+          { "==": ["x", "y"] }
+        ]
+      },
+      nil
     )
   end
 


### PR DESCRIPTION
As same as [JavaScript Implementation](https://github.com/jwadhams/json-logic-js/blob/master/logic.js#L280-L282), I'd like to add the feature for `filter` logic to return an empty array if the given object is not an array.