### PR TITLE
Type check for Array in 'some' operation

### DIFF
--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -11,6 +11,8 @@ module JSONLogic
         present.size >= v[0] ? [] : LAMBDAS['missing'].call(v[1], d)
       },
       'some' => -> (v,d) do
+        return false unless v[0].is_a?(Array)
+
         v[0].any? do |val|
           interpolated_block(v[1], val).truthy?
         end


### PR DESCRIPTION
I noticed while using this gem that if you use the 'some' operation and pass `nil` in your var data it will attempt to call `any?` on nil and raise an error. Very simple check that ensures the operation is done on an Array, returning false if not