### PR TITLE
fix: Fix uses_data to resolve var arrays correctly

### DIFF
--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -32,7 +32,7 @@ module JSONLogic
 
       if operator == 'var' # TODO: It may be that non-var operators use data so we may want a flag or collection that indicates data use.
         if values[0] != JSONLogic::ITERABLE_KEY
-          collection << values[0]
+          collection |= values
         end
       else
         values.each do |val|

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -120,6 +120,15 @@ class JSONLogicTest < Minitest::Test
         ]
       }
     )
+
+    assert_equal ["a", "b", "c"], JSONLogic.uses_data(
+      {
+        "all" => [
+          { "var"=> "a" },
+          { "var"=> ["b", "c"] },
+        ]
+      }
+    )
   end
 
   def test_uses_data_missing


### PR DESCRIPTION
    There is a bug within uses_data. It takes only the first value for var values. It should take all. Consider the below example

    ```
    {
      "all" => [
        { "var"=> "a" },
        { "var"=> ["b", "c"] }
      ],
    }
    ```
    Calling `uses_data` on this should yield `["a", "b", "c"]` but instead only yields ["a", "b"].

    Testing this on the online playground at https://jsonlogic.com/play.html with the data `{ "a": ["foo", "bar", "baz"], "b": "foo", "c": "bar" }` yields true. The actual JSONLogic is correct here but specifically `uses_data` is incorrect.

    This PR attempts to fix this by always taking all values instead of the first.