### PR TITLE
Do not allocate more objects if already stringified

### DIFF
--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -12,7 +12,7 @@ module JSONLogic
       # Pass-thru
       logic
     else
-      if data.is_a?(Hash)
+      if data.is_a?(Hash) && data.keys.any?(Symbol)
         data = data.stringify_keys
       end
       data ||= {}


### PR DESCRIPTION
under heavy load this create a lot allocation + GC work for us, we want the opportunity to refactor our work by only pass in stringified keys data.