### PR TITLE
Fix bug where add_operation manipulates the Object class

### DIFF
--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -61,7 +61,7 @@ module JSONLogic
   end
 
   def self.add_operation(operator, function)
-    Operation.class.send(:define_method, operator) do |v, d|
+    Operation.define_singleton_method(operator) do |v, d|
       function.call(v, d)
     end
   end

--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -144,11 +144,5 @@ module JSONLogic
     def self.is_iterable?(operator)
       ['filter', 'some', 'all', 'none', 'in', 'map', 'reduce'].include?(operator.to_s)
     end
-
-    def self.add_operation(operator, function)
-      self.class.send(:define_method, operator) do |v, d|
-        function.call(v, d)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Problem

The `add_operation` is manipulating the `Object` class.
It can add new methods to object as well as overwrite existing methods.

```ruby
Object.sum
# Traceback (most recent call last):
#         4: from /Users/peterlanglois/.rvm/rubies/ruby-2.6.7/bin/irb:23:in `<main>'
#         3: from /Users/peterlanglois/.rvm/rubies/ruby-2.6.7/bin/irb:23:in `load'
#         2: from /Users/peterlanglois/.rvm/rubies/ruby-2.6.7/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
#         1: from (irb):40
# NoMethodError (undefined method `sum' for Object:Class)
JSONLogic.add_operation('sum', ->(v, _d) { v.sum })
Object.sum([1,2,3], {}) 
# 6
```

## Solution

Replace `define_method` with `define_singleton_method`.

```ruby
Object.sum
# Traceback (most recent call last):
#         4: from /Users/peterlanglois/.rvm/rubies/ruby-3.0.0/bin/irb:23:in `<main>'
#         3: from /Users/peterlanglois/.rvm/rubies/ruby-3.0.0/bin/irb:23:in `load'
#         2: from /Users/peterlanglois/.rvm/rubies/ruby-3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
#         1: from (irb):2:in `<main>'
# NoMethodError (undefined method `sum' for Object:Class)
JSONLogic.add_operation('sum', ->(v, _d) { v.sum })
Object.sum([1,2,3], {})
# Traceback (most recent call last):
#         4: from /Users/peterlanglois/.rvm/rubies/ruby-3.0.0/bin/irb:23:in `<main>'
#         3: from /Users/peterlanglois/.rvm/rubies/ruby-3.0.0/bin/irb:23:in `load'
#         2: from /Users/peterlanglois/.rvm/rubies/ruby-3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
#         1: from (irb):4:in `<main>'
# NoMethodError (undefined method `sum' for Object:Class)
JSONLogic.apply({ sum: [1,2,3] }, {})
# 6
```