### PR TITLE
if fixes for no match and nil value

### DIFF
--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -79,10 +79,16 @@ module JSONLogic
         end
       end,
       'if' => ->(v, d) {
-        v.each_slice(2) do |condition, value|
-          return condition if value.nil?
-          return value if condition.truthy?
+        v.each_slice(2) do |condition_and_value|
+          # If this slice a single value? It's an else value only.
+          if condition_and_value.size == 1
+            return condition_and_value.first
+          else
+            condition, value = condition_and_value
+            return value if condition.truthy?
+          end
         end
+        nil
       },
       '=='    => ->(v, d) { v[0].to_s == v[1].to_s },
       '==='   => ->(v, d) { v[0] == v[1] },

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -8,7 +8,7 @@ require 'json_logic'
 
 class JSONLogicTest < Minitest::Test
   test_suite_url = 'http://jsonlogic.com/tests.json'
-  tests = JSON.parse(open(test_suite_url).read)
+  tests = JSON.parse(URI.open(test_suite_url).read)
   count = 1
   tests.each do |pattern|
     next unless pattern.is_a?(Array)


### PR DESCRIPTION
Updates the if statement to fix:

* #41 by explicitly returning nil and not defaulting to the return of `each_slice`.
* #42 by better detection of else values which is not dependent on the value being passed.

Also a minor fix to the `open-uri` use for the latest(?) API.

This change causes 4 failing tests from the test suite cases provided by http://jsonlogic.com/tests.json to all pass:

```ruby
  1) Failure:
JSONLogicTest#test_170 [test/json_logic_test.rb:20]:
{"if":[false,"apple",false,"banana"]} (data: null).
Expected [false, "apple", false, "banana"] to be nil.

  2) Failure:
JSONLogicTest#test_125 [test/json_logic_test.rb:20]:
{"if":[]} (data: null).
Expected [] to be nil.

  3) Failure:
JSONLogicTest#test_175 [test/json_logic_test.rb:20]:
{"if":[false,"apple",false,"banana",false,"carrot"]} (data: null).
Expected [false, "apple", false, "banana", false, "carrot"] to be nil.

  4) Failure:
JSONLogicTest#test_130 [test/json_logic_test.rb:20]:
{"if":[false,"apple"]} (data: null).
Expected [false, "apple"] to be nil.
```